### PR TITLE
Improve step navigation and mobile UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,13 @@
             </div>
         </header>
 
+        <!-- 大きなステップ表示 -->
+        <nav class="main-step-tracker" aria-label="ステップ概要">
+            <div class="main-step active" data-phase="1" aria-current="step">はじめに</div>
+            <div class="main-step" data-phase="2">入力</div>
+            <div class="main-step" data-phase="3">結果</div>
+        </nav>
+
         <!-- プログレスセクション -->
         <section class="progress-section" aria-label="進捗状況">
             <div class="progress-container">
@@ -973,16 +980,14 @@
             
             <nav class="step-navigation" aria-label="アクションメニュー">
                 <div class="step-buttons">
-                    <button class="btn btn--secondary" onclick="prevStep()">
-                        <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-left"></use></svg>
-                        <span>設定を修正</span>
-                    </button>
                     <button class="btn btn--outline" onclick="resetApp()">
-                        <span>最初からやり直す</span>
+                        <span>もう一度やり直す</span>
                     </button>
-                    <button class="btn btn--success" onclick="exportResults()">
-                        <span>結果をエクスポート</span>
-                        <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-download"></use></svg>
+                    <button class="btn btn--secondary" onclick="saveSettings()">
+                        <span>設定を保存する</span>
+                    </button>
+                    <button class="btn btn--success" onclick="scrollToAdvice()">
+                        <span>アドバイスを見る</span>
                     </button>
                 </div>
                 <div class="step-info completed">

--- a/script.js
+++ b/script.js
@@ -532,6 +532,16 @@ const UIManager = {
         }
 
         this.updateStepLabels();
+        this.updateMainSteps();
+    },
+
+    // メインステップ更新
+    updateMainSteps() {
+        const phaseMap = { 1: 1, 2: 2, 3: 2, 4: 2, 5: 3 };
+        const currentPhase = phaseMap[appState.currentStep] || 1;
+        document.querySelectorAll('.main-step').forEach((step, index) => {
+            step.classList.toggle('active', index === currentPhase - 1);
+        });
     },
 
     // ステップラベル更新
@@ -2646,6 +2656,17 @@ const AppInitializer = {
         window.calculateResults = () => CalculationEngine.calculate();
         window.resetApp = () => this.resetApplication();
         window.exportResults = () => this.exportResults();
+        window.saveSettings = () => {
+            if (StorageManager.save(appState)) {
+                NotificationManager.show('設定を保存しました', 'success');
+            }
+        };
+        window.scrollToAdvice = () => {
+            const adviceSection = document.querySelector('.advice-section');
+            if (adviceSection) {
+                Utils.scrollToElement(adviceSection, 100);
+            }
+        };
     },
 
     setupAdvancedSettingsListeners() {

--- a/style.css
+++ b/style.css
@@ -270,6 +270,28 @@ body {
     font-size: var(--text-base);
 }
 
+/* ===== 大きなステップ表示 ===== */
+.main-step-tracker {
+    display: flex;
+    justify-content: space-around;
+    margin: var(--space-10) 0;
+}
+
+.main-step {
+    flex: 1;
+    text-align: center;
+    font-size: var(--text-xl);
+    font-weight: var(--font-semibold);
+    padding-bottom: var(--space-2);
+    border-bottom: 4px solid var(--color-secondary-300);
+    color: var(--color-text-tertiary);
+}
+
+.main-step.active {
+    border-color: var(--color-primary-500);
+    color: var(--color-primary-700);
+}
+
 /* ===== プログレスセクション ===== */
 .progress-section {
     margin-bottom: var(--space-16);
@@ -2400,6 +2422,22 @@ select.form-control {
     }
 
     .card {
+        padding: var(--space-4);
+    }
+
+    .main-step-tracker {
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+
+    .main-step {
+        font-size: var(--text-lg);
+        border-bottom-width: 2px;
+    }
+
+    .form-control,
+    .btn {
+        font-size: var(--text-lg);
         padding: var(--space-4);
     }
 


### PR DESCRIPTION
## Summary
- add large step tracker so users know "はじめに→入力→結果" progress
- enlarge controls on small screens
- add buttons for redo, save settings and view advice
- update scripts to highlight main steps and support new buttons

## Testing
- `node -e "require('./script.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68405f70b6c483269c6cd349960b230e