### PR TITLE
Improve usability with quick guide and export

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,15 @@
         </symbol>
     </svg>
 
+    <div id="quickGuideOverlay" class="quick-guide-overlay" style="display:none;">
+        <div class="quick-guide-content">
+            <p>まずここを押して基本情報を入力しよう</p>
+            <span class="quick-guide-arrow">⬇️</span>
+            <button type="button" class="btn btn--primary" onclick="closeQuickGuide()">スタート</button>
+        </div>
+    </div>
+
+
     <div class="container">
         <!-- ヘッダーセクション -->
         <header class="header" role="banner">
@@ -988,6 +997,9 @@
                     </button>
                     <button class="btn btn--success" onclick="scrollToAdvice()">
                         <span>アドバイスを見る</span>
+                    </button>
+                    <button class="btn btn--primary" onclick="exportResults()">
+                        <span>結果をダウンロード</span>
                     </button>
                 </div>
                 <div class="step-info completed">

--- a/script.js
+++ b/script.js
@@ -517,15 +517,16 @@ const UIManager = {
         progressFill.setAttribute('aria-valuenow', percentage);
         
         if (progressPercentage) {
+        const remaining = 100 - percentage;
             progressPercentage.textContent = `${percentage}%`;
         }
         
         if (progressSummary) {
             const messages = {
-                1: 'ステップ 1 / 5 を入力中 - 基本情報',
-                2: 'ステップ 2 / 5 を入力中 - 固定費',
-                3: 'ステップ 3 / 5 を入力中 - ライフイベント',
-                4: 'ステップ 4 / 5 を入力中 - 詳細設定',
+                1: 'ステップ 1 / 5 (残り ' + remaining + '%) - 基本情報',
+                2: 'ステップ 2 / 5 (残り ' + remaining + '%) - 固定費',
+                3: 'ステップ 3 / 5 (残り ' + remaining + '%) - ライフイベント',
+                4: 'ステップ 4 / 5 (残り ' + remaining + '%) - 詳細設定',
                 5: 'シミュレーション完了！'
             };
             progressSummary.textContent = messages[appState.currentStep] || '';
@@ -704,7 +705,23 @@ const UIManager = {
             if (advicePlaceholder) advicePlaceholder.style.display = 'flex';
             if (adviceContent) adviceContent.style.display = 'none';
         }
-    }
+    },
+    // クイックガイド表示
+    showQuickGuide() {
+        const overlay = Utils.getElement("quickGuideOverlay", false);
+        if (overlay && !localStorage.getItem("guideShown")) {
+            overlay.style.display = "flex";
+        }
+    },
+
+    // クイックガイド非表示
+    closeQuickGuide() {
+        const overlay = Utils.getElement("quickGuideOverlay", false);
+        if (overlay) {
+            overlay.style.display = "none";
+        }
+        localStorage.setItem("guideShown", "1");
+    },
 };
 
 // ===== フォーム管理システム =====
@@ -2667,6 +2684,7 @@ const AppInitializer = {
                 Utils.scrollToElement(adviceSection, 100);
             }
         };
+        window.closeQuickGuide = () => UIManager.closeQuickGuide();
     },
 
     setupAdvancedSettingsListeners() {
@@ -2776,6 +2794,7 @@ const AppInitializer = {
         // 固定費サマリー更新
         FixedCostManager.updateSummary();
         
+        UIManager.showQuickGuide();
         // ライフイベント詳細設定の可視性更新
         LifeEventManager.updateDetailSettingsVisibility();
     },

--- a/style.css
+++ b/style.css
@@ -2212,6 +2212,31 @@ select.form-control {
     font-weight: var(--font-semibold);
 }
 
+/* ===== クイックガイド ===== */
+.quick-guide-overlay {
+    position: fixed;
+    inset: 0;
+    display: none;
+    background: rgba(0, 0, 0, 0.6);
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    text-align: center;
+    padding: var(--space-4);
+}
+.quick-guide-content {
+    background: var(--color-primary-600);
+    color: #fff;
+    padding: var(--space-6);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+}
+.quick-guide-arrow {
+    display: block;
+    font-size: var(--text-4xl);
+    margin: var(--space-2) 0 var(--space-4);
+}
+
 /* ===== フッター ===== */
 .footer {
     margin-top: var(--space-20);
@@ -2450,6 +2475,9 @@ select.form-control {
     .range-min,
     .range-max {
         min-width: auto;
+    }
+    .quick-guide-content {
+        width: 90%;
     }
 }
 


### PR DESCRIPTION
## Summary
- add an introductory quick guide overlay to help first time users
- allow exporting results from the final step
- style and script updates for the new guide and progress messages

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68406409097c8326bb004e4a9eee8178