### PR TITLE
Add PDF export functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -1037,6 +1037,7 @@
         </div>
     </footer>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-/5ryuVKyXjHimoMuquxYZc13JUO2c+hJ1ytY1/6V2vNhbbX6YsJhBKt3vnDnN/SUXOcDSBx/OVCkXbkqNpN/mg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -2900,7 +2900,7 @@ const AppInitializer = {
             }
 
             const exportData = this.generateExportData();
-            this.downloadExportData(exportData);
+            this.downloadExportPDF(exportData);
             
         } catch (error) {
             Utils.handleError(error, 'Results export');
@@ -3026,6 +3026,16 @@ const AppInitializer = {
         URL.revokeObjectURL(url);
         
         NotificationManager.show('結果をJSONファイルとしてエクスポートしました', 'success');
+    },
+
+    downloadExportPDF(data) {
+        const doc = new jspdf.jsPDF();
+        const text = JSON.stringify(data, null, 2);
+        const lines = doc.splitTextToSize(text, 180);
+        doc.text(lines, 10, 10);
+        doc.save(`生涯収支シミュレーション結果_${new Date().toISOString().slice(0, 10)}.pdf`);
+
+        NotificationManager.show('結果をPDFファイルとしてエクスポートしました', 'success');
     }
 };
 


### PR DESCRIPTION
## Summary
- include jsPDF library
- export results as PDF instead of JSON

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840699d7cac8326a4ad24e4ce7c602e