### PR TITLE
Add SNS share and chart image download

### DIFF
--- a/index.html
+++ b/index.html
@@ -1001,6 +1001,12 @@
                     <button class="btn btn--primary" onclick="exportResults()">
                         <span>結果をダウンロード</span>
                     </button>
+                    <button class="btn btn--secondary" onclick="downloadChartImage()">
+                        <span>グラフを画像保存</span>
+                    </button>
+                    <button class="btn btn--secondary" onclick="shareResults()">
+                        <span>SNSで共有</span>
+                    </button>
                 </div>
                 <div class="step-info completed">
                     <span class="step-counter">完了</span>


### PR DESCRIPTION
## Summary
- add buttons for chart image saving and SNS sharing
- implement `downloadChartImage` and `shareResults` in script
- expose new functions globally

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406b7578648326beccac42c333017f