### PR TITLE
Add error handling for Chart.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>人生おかね診断 - あなたの未来の家計を診断</title>
     <meta name="description" content="簡単な質問に答えるだけで、生涯にわたる収支と資産推移をシミュレーション。老後資金計画に役立つアドバイスも提供します。">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
+<!-- Chart.jsの読み込み。失敗したらコンソールにエラーメッセージを出します -->
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js' onerror='console.error("Chart.js failed to load from CDN")'></script>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- log an error when Chart.js fails to load from the CDN

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68407abb2d0c8326b4348420f554392f