### PR TITLE
Fix Utils.parseInt recursion bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -874,7 +874,7 @@ const Utils = {
 
     // 安全な整数解析
     parseInt(value, defaultValue = 0, min = -Infinity, max = Infinity) {
-        const num = parseInt(value);
+        const num = Number.parseInt(value, 10);
         if (isNaN(num)) return defaultValue;
         return Math.max(min, Math.min(max, num));
     },


### PR DESCRIPTION
## Summary
- prevent infinite recursion by calling the built-in `Number.parseInt`

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6840adccef608326829520576889b6b3