### PR TITLE
Implement unified navigation and add test infra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm test

--- a/index.html
+++ b/index.html
@@ -535,7 +535,7 @@
             
             <nav class="step-navigation" aria-label="ステップナビゲーション">
                 <div class="step-buttons">
-                    <button class="btn btn--primary btn--large" onclick="nextStep()">
+                    <button class="btn btn--primary btn--large" onclick="NavigationManager.nextStep()">
                         <span>次へ：固定費入力</span>
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-right"></use></svg>
                     </button>
@@ -606,11 +606,11 @@
             
             <nav class="step-navigation" aria-label="ステップナビゲーション">
                 <div class="step-buttons">
-                    <button class="btn btn--secondary" onclick="prevStep()">
+                    <button class="btn btn--secondary" onclick="NavigationManager.previousStep()">
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-left"></use></svg>
                         <span>戻る</span>
                     </button>
-                    <button class="btn btn--primary btn--large" onclick="nextStep()">
+                    <button class="btn btn--primary btn--large" onclick="NavigationManager.nextStep()">
                         <span>次へ：ライフイベント</span>
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-right"></use></svg>
                     </button>
@@ -800,11 +800,11 @@
             
             <nav class="step-navigation" aria-label="ステップナビゲーション">
                 <div class="step-buttons">
-                    <button class="btn btn--secondary" onclick="prevStep()">
+                    <button class="btn btn--secondary" onclick="NavigationManager.previousStep()">
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-left"></use></svg>
                         <span>戻る</span>
                     </button>
-                    <button class="btn btn--primary btn--large" onclick="nextStep()">
+                    <button class="btn btn--primary btn--large" onclick="NavigationManager.nextStep()">
                         <span>次へ：詳細設定</span>
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-right"></use></svg>
                     </button>
@@ -915,7 +915,7 @@
             
             <nav class="step-navigation" aria-label="ステップナビゲーション">
                 <div class="step-buttons">
-                    <button class="btn btn--secondary" onclick="prevStep()">
+                    <button class="btn btn--secondary" onclick="NavigationManager.previousStep()">
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-left"></use></svg>
                         <span>戻る</span>
                     </button>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "lifemoneyplan",
+  "version": "1.0.0",
+  "description": "",
+  "main": "perfMonitor.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.42.1"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,8 @@
+// @ts-check
+const { defineConfig } = require('@playwright/test');
+module.exports = defineConfig({
+  testDir: './tests',
+  use: {
+    headless: true,
+  }
+});

--- a/script.js
+++ b/script.js
@@ -362,57 +362,6 @@ const premiumUX = new PremiumUXManager();
 
 // ===== 基本的なナビゲーション関数 =====
 
-// 次のステップに進む
-function nextStep() {
-    if (appState.currentStep < 5) {
-        // 現在のステップを非表示
-        const currentSection = document.getElementById(`step${appState.currentStep}`);
-        if (currentSection) {
-            currentSection.classList.remove('active');
-        }
-        
-        // 次のステップを表示
-        appState.currentStep++;
-        const nextSection = document.getElementById(`step${appState.currentStep}`);
-        if (nextSection) {
-            nextSection.classList.add('active');
-        }
-        
-        // プログレスバーを更新
-        updateProgressBar();
-        
-        // プレミアムUX通知
-        premiumUX.showNotification('success', 'ステップ完了', 
-            `ステップ${appState.currentStep-1}が完了しました。次に進みます。`);
-        
-        // ページトップにスクロール
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
-}
-
-// 前のステップに戻る
-function prevStep() {
-    if (appState.currentStep > 1) {
-        // 現在のステップを非表示
-        const currentSection = document.getElementById(`step${appState.currentStep}`);
-        if (currentSection) {
-            currentSection.classList.remove('active');
-        }
-        
-        // 前のステップを表示
-        appState.currentStep--;
-        const prevSection = document.getElementById(`step${appState.currentStep}`);
-        if (prevSection) {
-            prevSection.classList.add('active');
-        }
-        
-        // プログレスバーを更新
-        updateProgressBar();
-        
-        // ページトップにスクロール
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
-}
 
 // プログレスバーの更新
 function updateProgressBar() {
@@ -545,7 +494,7 @@ function calculateResults() {
                 loading.setAttribute('aria-hidden', 'true');
             }
 
-            nextStep();
+            NavigationManager.nextStep();
             ResultsManager.render();
 
             premiumUX.showNotification('success', '計算完了',
@@ -2734,6 +2683,8 @@ const StepValidator = {
                 }, 300);
             }
         }
+
+        return errors.size;
     }
 };
 
@@ -2741,10 +2692,16 @@ const StepValidator = {
 const NavigationManager = {
     nextStep() {
         const errors = StepValidator.validateStep(appState.currentStep);
-        
-        if (errors.size > 0) {
-            StepValidator.showValidationErrors(errors);
-            NotificationManager.show('入力内容を確認してください', 'error');
+        const errorCount = StepValidator.showValidationErrors(errors);
+        if (errorCount > 0) {
+            NotificationManager.show('入力を確認してね！', 'error');
+            console.warn(errors);
+            const currentSection = Utils.getElement(`step${appState.currentStep}`, false);
+            const nextBtn = currentSection?.querySelector('.step-navigation .btn--primary.btn--large');
+            if (nextBtn) {
+                nextBtn.classList.add('btn--shake');
+                setTimeout(() => nextBtn.classList.remove('btn--shake'), 300);
+            }
             return;
         }
 

--- a/style.css
+++ b/style.css
@@ -2053,6 +2053,16 @@ select.form-control {
     left: 100%;
 }
 
+@keyframes btnShake {
+    0%,100% { transform: translateX(0); }
+    25% { transform: translateX(-4px); }
+    75% { transform: translateX(4px); }
+}
+
+.btn--shake {
+    animation: btnShake .3s;
+}
+
 /* ===== ステップナビゲーション ===== */
 .step-navigation {
     margin-top: var(--space-10);

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -1,0 +1,26 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test('can reach results page', async ({ page }) => {
+  const fileUrl = 'file://' + path.resolve(__dirname, '../index.html');
+  await page.goto(fileUrl);
+
+  await page.selectOption('#birthYear', { label: '1985年' });
+  await page.selectOption('#birthMonth', { value: '1' });
+  await page.fill('#income', '30');
+  await page.selectOption('#occupation', 'employee');
+
+  await page.click('#step1 button.btn--primary');
+
+  const costIds = ['housing','food','utilities','communication','insurance','vehicle','education','subscriptions','others'];
+  for (const id of costIds) {
+    await page.fill(`#cost-${id}`, '0');
+  }
+  await page.click('#step2 button.btn--primary');
+
+  await page.click('#step3 button.btn--primary');
+
+  await page.click('#step4 button.btn--calculate');
+
+  await expect(page.locator('#step5')).toHaveClass(/active/);
+});


### PR DESCRIPTION
## Summary
- call NavigationManager directly from HTML buttons
- remove old next/prev functions and update logic
- show toast and button shake when validation fails
- add Playwright E2E test and CI workflow

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e66965b48326924f06a74afea4be