### PR TITLE
Add validation status element

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,7 +532,10 @@
                     </div>
                 </div>
             </div>
-            
+
+            <!-- 入力内容の検証結果を表示 -->
+            <div id="validationStatus" class="validation-status" style="margin: 2rem 0;"></div>
+
             <nav class="step-navigation" aria-label="ステップナビゲーション">
                 <div class="step-buttons">
                     <button class="btn btn--primary btn--large" onclick="NavigationManager.nextStep()">

--- a/script.js
+++ b/script.js
@@ -2684,7 +2684,23 @@ const StepValidator = {
             }
         }
 
+        this.updateStatus(errors);
         return errors.size;
+    },
+
+    updateStatus(errors) {
+        const statusEl = Utils.getElement('validationStatus', false);
+        if (!statusEl) return;
+
+        if (errors.size === 0) {
+            statusEl.textContent = '入力は問題ありません';
+            statusEl.classList.remove('error');
+            statusEl.classList.add('success');
+        } else {
+            statusEl.textContent = `入力エラーが${errors.size}件あります`;
+            statusEl.classList.remove('success');
+            statusEl.classList.add('error');
+        }
     }
 };
 

--- a/style.css
+++ b/style.css
@@ -1012,6 +1012,21 @@ select.form-control {
     font-size: var(--text-base);
 }
 
+/* ===== バリデーションステータス表示 ===== */
+.validation-status {
+    text-align: center;
+    font-size: var(--text-base);
+    font-weight: var(--font-semibold);
+}
+
+.validation-status.success {
+    color: var(--color-success-600);
+}
+
+.validation-status.error {
+    color: var(--color-error-600);
+}
+
 /* ===== ツールチップ ===== */
 .tooltip-trigger {
     background: none;


### PR DESCRIPTION
## Summary
- add validation status container to step 1
- display validation results with new styles
- update script to show overall validation status

## Testing
- `npm test` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840eaef5ec48326884b8593ab7ec66b