### PR TITLE
Fix navigation buttons and add e2e test

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,7 +538,7 @@
 
             <nav class="step-navigation" aria-label="ステップナビゲーション">
                 <div class="step-buttons">
-                    <button class="btn btn--primary btn--large" onclick="NavigationManager.nextStep()">
+                    <button class="btn btn--primary btn--large" onclick="nextStep()">
                         <span>次へ：固定費入力</span>
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-right"></use></svg>
                     </button>
@@ -609,11 +609,11 @@
             
             <nav class="step-navigation" aria-label="ステップナビゲーション">
                 <div class="step-buttons">
-                    <button class="btn btn--secondary" onclick="NavigationManager.previousStep()">
+                    <button class="btn btn--secondary" onclick="prevStep()">
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-left"></use></svg>
                         <span>戻る</span>
                     </button>
-                    <button class="btn btn--primary btn--large" onclick="NavigationManager.nextStep()">
+                    <button class="btn btn--primary btn--large" onclick="nextStep()">
                         <span>次へ：ライフイベント</span>
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-right"></use></svg>
                     </button>
@@ -803,11 +803,11 @@
             
             <nav class="step-navigation" aria-label="ステップナビゲーション">
                 <div class="step-buttons">
-                    <button class="btn btn--secondary" onclick="NavigationManager.previousStep()">
+                    <button class="btn btn--secondary" onclick="prevStep()">
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-left"></use></svg>
                         <span>戻る</span>
                     </button>
-                    <button class="btn btn--primary btn--large" onclick="NavigationManager.nextStep()">
+                    <button class="btn btn--primary btn--large" onclick="nextStep()">
                         <span>次へ：詳細設定</span>
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-right"></use></svg>
                     </button>
@@ -918,7 +918,7 @@
             
             <nav class="step-navigation" aria-label="ステップナビゲーション">
                 <div class="step-buttons">
-                    <button class="btn btn--secondary" onclick="NavigationManager.previousStep()">
+                    <button class="btn btn--secondary" onclick="prevStep()">
                         <svg class="btn-icon" aria-hidden="true"><use xlink:href="#icon-arrow-left"></use></svg>
                         <span>戻る</span>
                     </button>

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -1,6 +1,20 @@
 const { test, expect } = require('@playwright/test');
 const path = require('path');
 
+test('step1 to step2 navigation works', async ({ page }) => {
+  const fileUrl = 'file://' + path.resolve(__dirname, '../index.html');
+  await page.goto(fileUrl);
+
+  await page.selectOption('#birthYear', { label: '1985年' });
+  await page.selectOption('#birthMonth', { value: '1' });
+  await page.fill('#income', '30');
+  await page.selectOption('#occupation', 'employee');
+
+  await page.click('#step1 button.btn--primary');
+
+  await expect(page.locator('#step2')).toHaveClass(/active/);
+});
+
 test('can reach results page', async ({ page }) => {
   const fileUrl = 'file://' + path.resolve(__dirname, '../index.html');
   await page.goto(fileUrl);


### PR DESCRIPTION
## Summary
- fix step navigation buttons to use global helpers
- add e2e test verifying navigation from step1 to step2

## Testing
- `npm test` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840ff2e101c8326920e9e1360457ef2